### PR TITLE
Implement save order functionality

### DIFF
--- a/controllers/order-controller.js
+++ b/controllers/order-controller.js
@@ -208,9 +208,39 @@ const orderController = {
 						let preferredDeliveryDate = req.body.preferredDeliveryDate;
 						let paymentType = req.body.paymentType;
 						let orderPrice = req.body.orderTotalPrice;
-
 						let isCompanyLogoUploaded = req.body.isCompanyLogoUploaded;
 						let origCompanyLogo = req.body.origCompanyLogo;
+
+						/* Store the order item data from the order page */
+						let orderItemIds = req.body.orderItemId;
+						let orderItemQuantities = req.body.orderItemQuantity;
+						let orderItemPackagingTypes = req.body.orderItemPackagingType;
+						let orderItemPackagingColors = req.body.orderItemPackagingColor;
+						let orderItemPackagingMessages = req.body.orderItemPackagingMessage;
+						let orderItemColors = req.body.orderItemColor;
+						let orderItemTexts = req.body.orderItemText;
+						let orderItemCompanyLogos = req.body.orderItemCompanyLogo;
+						let orderItemLogoLocations = req.body.logoLocation;
+						let orderItemAdditionalInstructions = req.body.orderItemAdditionalInstructions;
+						let orderItemPrices = req.body.orderItemPrice;
+
+						/* Assign the data from the above arrays into an array of order item details */
+						let orderItemDetails = [];
+
+						for (let i = 0; i < orderItemIds.length; i++) {
+							orderItemDetails[i] = {
+							    quantity: orderItemQuantities[i],
+								packaging: orderItemPackagingTypes[i],
+								packagingColor: orderItemPackagingColors[i],
+								packagingMessage: orderItemPackagingMessages[i],
+								itemColor: orderItemColors[i],
+								itemText: orderItemTexts[i],
+								includeCompanyLogo: orderItemCompanyLogos[i],
+								companyLogoLocation: orderItemLogoLocations[i],
+								additionalInstructions: orderItemAdditionalInstructions[i].trim(),
+							//	orderItemPrice: orderItemPrices[i]
+							}
+						}
 
 						let companyLogo = "";
 						if (req.file != null) {
@@ -250,13 +280,18 @@ const orderController = {
 								 */
 								let updatedOrderItemIds = [];
 
+								/* Create another array to store the updated order item details */
+								let updatedOrderItemDetails = [];
+
 								/* If the ObjectID of an order item is in the list of removed order item IDs,
-								 * exclude it from the list of updated order item IDs
+								 * exclude it from the list of updated order item IDs; similarly, exclude its
+								 * details from the list of updated order item details
 								 */
 								let j = 0;
 								for (let i = 0; i < order.orderItemIds.length; i++) {
 									if (removedOrderItemArray.includes(order.orderItemIds[i]) == false) {
 										updatedOrderItemIds[j] = order.orderItemIds[i];
+										updatedOrderItemDetails[j] = orderItemDetails[i];
 										j++;
 									}
 								}
@@ -277,12 +312,18 @@ const orderController = {
 								}
 								
 								db.updateOne(Order, filter, update, function(flag) {
+									
+									for (let i = 0; i < updatedOrderItemIds.length; i++) {
+										orderItemFilter = {_id: updatedOrderItemIds[i]};
+										orderItemUpdate = updatedOrderItemDetails[i];
+
+										db.updateOneIterative(OrderItem, orderItemFilter, orderItemUpdate);
+									}
+									
 									res.status(200).json(orderId);
 									res.send();
 								});
 							});
-
-							// edit remaining order item details
 						});
 					}
 				}	

--- a/models/db.js
+++ b/models/db.js
@@ -323,7 +323,18 @@ const database = {
      */
     convertToObjectId: function(id) {
         return mongoose.Types.ObjectId(id);
-    }
+    },
+
+    updateOneIterative: function(model, filter, update) {
+        model.updateOne (filter, update, function(error, result) {
+            if (error) {
+                console.log('Error');
+            } else {
+                console.log('Document modified: ' + result.nModified);
+                console.log(result);
+            }
+        });
+    },
 }
 
 module.exports = database;

--- a/views/partials/order-specific.hbs
+++ b/views/partials/order-specific.hbs
@@ -17,8 +17,7 @@
                 <input type="hidden" id = "order-item-id-{{orderItemId}}" name = "orderItemId" value = {{orderItemId}}>
 
                 <label for="quantity"><h5>Quantity</h5></label>
-                <input type="number" min = "1" max = "{{productQuantity}}" step = "1" id = "quantity-{{orderItemId}}" class="ms-3 item-quantity" value = {{quantity}}>
-                <input type="hidden" value = {{productQuantity}}>
+                <input type="number" min = "1" max = "{{productQuantity}}" step = "1" id = "quantity-{{orderItemId}}" name = "orderItemQuantity" class="ms-3 item-quantity" value = {{quantity}}>
 
                 <span id = "quantity-exceed-{{orderItemId}}">STYLE ME (IF EXCEEDING ORDER QUANTITY)</span>
             </div>
@@ -34,6 +33,9 @@
                     <h6 class="bold" >Packaging</h6>
 
                     <div  class="d-flex flex-row mt-3" id="packaging-radio">
+
+                        {{!-- INPUT FOR PACKAGING TYPE RADIO BUTTON --}}
+                        <input type = "hidden" id = "packaging-type-{{orderItemId}}" name = "orderItemPackagingType" value = "dummy">
 
                         <div class=" mx-2 form-check">
                             <input class="form-check-input" type="radio"  name="packaging_radio-{{orderItemId}}" id="packaging_kraft_box-{{orderItemId}}" value="kraft_box" checked>
@@ -58,14 +60,14 @@
                     </div>
 
                     <div class="d-flex flex-row justify-content-between mt-2">
-                        <select class="form-select w-50 mx-3" aria-label="Packaging Color Select">
+                        <select class="form-select w-50 mx-3" aria-label="Packaging Color Select" name = "orderItemPackagingColor">
                             <option value="packaging_color_1" selected>Packaging Color 1</option>
                             <option value="packaging_color_2">Packaging Color 2</option> 
                             <option value="packaging_color_3">Packaging Color 3</option> 
                             <option value="packaging_color_4">Packaging Color 4</option> 
                             <option value="packaging_color_5">Packaging Color 5</option> 
                         </select>
-                        <input type="text" class="mx-3" id="package-text-{{orderItemId}}" placeholder="Want to add a message? (Optional)"
+                        <input type="text" class="mx-3" id="package-text-{{orderItemId}}" name = "orderItemPackagingMessage" placeholder="Want to add a message? (Optional)"
                                value={{packagingMessage}}>
                     </div>
                    
@@ -76,7 +78,7 @@
                     <h6 class="bold">Item</h6>
 
                     <div class="d-flex flex-row justify-content-between mt-2">
-                        <select class="form-select w-50 mx-3" aria-label="Item Color Select">
+                        <select class="form-select w-50 mx-3" aria-label="Item Color Select" name = "orderItemColor">
                             <option value="item_color_1" selected>Item Color 1</option>
                             <option value="item_color_2">Item Color 2</option> 
                             <option value="item_color_3">Item Color 3</option> 
@@ -85,7 +87,7 @@
                         </select>
 
                         {{!-- Pweds palagay na limit ung text dito, parang mga 10-15 characters lang for now.. clarify ko lang kay Sab n Cheska kung pano itong part  --}}
-                        <input type="text" class="mx-3" id="item-text-{{orderItemId}}" placeholder="You can also add text here (Optional)"
+                        <input type="text" class="mx-3" id="item-text-{{orderItemId}}" name = "orderItemText" placeholder="You can also add text here (Optional)"
                                value={{itemText}}>
                     </div>                        
                 </div>
@@ -95,6 +97,9 @@
                     
 
                     <div  class="d-flex flex-row mt-3" id="logo_radio">
+
+                        {{!-- INPUT FOR COMPANY LOGO RADIO BUTTON --}}
+                        <input type = "hidden" id = "company-logo-{{orderItemId}}" name = "orderItemCompanyLogo" value = "dummy">
 
                         <div class=" mx-2 form-check">
                             <input class="form-check-input" type="radio"  name="logo_radio-{{orderItemId}}" id="logo_with-{{orderItemId}}" value="true" checked>
@@ -121,13 +126,16 @@
                 <div class="container ps-4 mt-4">
 
                     <h6 class="bold">Additional Instructions</h6>
-                    <textarea rows="5" cols="100" id="orderID_productID_addl-instructions-{{orderItemId}}" style="resize: none;" placeholder="If you want anything else with this particular product..."
-                              value={{additionalInstructions}}>
-
+                    <textarea rows="5" cols="100" id="orderID_productID_addl-instructions-{{orderItemId}}" name = "orderItemAdditionalInstructions" 
+                              style="resize: none;" placeholder="If you want anything else with this particular product...">
+                        {{additionalInstructions}}
                     </textarea>
                 </div>
 
                 <div class="container ps-4 mt-4">
+                    {{!-- INPUT FOR ORDER ITEM PRICE --}}
+                    <input type = "hidden" id = "order-item-price-hidden-{{orderItemId}}" name = "orderItemPrice" value = "dummy">
+
                     <h4><span class="bold">Total:</span> ₱<span id = "order-item-price-{{orderItemId}}" class = "order-item-price">{{orderItemPrice}}</span></h4>
                 </div>
 

--- a/views/partials/order-with-logo.hbs
+++ b/views/partials/order-with-logo.hbs
@@ -4,6 +4,9 @@
     <div class="mt-4">
         <h6>Where do you want to put the logo?</h6>
 
+        {{!-- INPUT FOR COMPANY LOGO LOCATION CHECKBOX --}}
+        <input type = "hidden" id = "logo-location-{{orderItemId}}" name = "logoLocation" value = "['items', 'packaging']">
+
         <div class="form-check">
             <input class="form-check-input" type="checkbox" value="items" id="logo_on_items-{{orderItemId}}">
             <label class="form-check-label" for="logo_on_items">


### PR DESCRIPTION
Fully implement the save order functionality, including saving order item details

TODO @memgonzales 
- Upon opening the order, only expand the accordion for the last order item
- Assign the values from the radio buttons (packaging type and presence of company logo) to their corresponding hidden input fields for data retrieval
- Assign the values from the checkbox (company logo location) to the corresponding hidden input field, preferably in array format
- Assign the value for the order item price to the corresponding hidden input field

(Note: The hidden input fields for the needed data are marked by comments in the order-specific and order-with-logo js files)