### PR TITLE
Handle the case when the user orders only a single product

### DIFF
--- a/controllers/order-controller.js
+++ b/controllers/order-controller.js
@@ -224,6 +224,20 @@ const orderController = {
 						let orderItemAdditionalInstructions = req.body.orderItemAdditionalInstructions;
 						let orderItemPrices = req.body.orderItemFinalPrice;
 
+						if (!(orderItemIds instanceof Array)) {
+							orderItemIds = [orderItemIds];
+							orderItemQuantities = [orderItemQuantities];
+							orderItemPackagingTypes = [orderItemPackagingTypes];
+							orderItemPackagingColors = [orderItemPackagingColors];
+							orderItemPackagingMessages = [orderItemPackagingMessages];
+							orderItemColors = [orderItemColors];
+							orderItemTexts = [orderItemTexts];
+							orderItemCompanyLogos = [orderItemCompanyLogos];
+							orderItemLogoLocations = [orderItemLogoLocations];
+							orderItemAdditionalInstructions = [orderItemAdditionalInstructions];
+							orderItemPrices = [orderItemPrices];
+						}
+
 						console.log(orderItemIds);
 						console.log(orderItemQuantities);
 						console.log(orderItemPackagingTypes);
@@ -235,6 +249,7 @@ const orderController = {
 						console.log(orderItemLogoLocations);
 						console.log(orderItemAdditionalInstructions);
 						console.log(orderItemPrices);
+
 
 						/* Assign the data from the above arrays into an array of order item details */
 						let orderItemDetails = [];

--- a/public/js/order-specific.js
+++ b/public/js/order-specific.js
@@ -133,7 +133,12 @@ $(document).ready(function() {
         const orderItemId = getOrderItemId(this);
         const data = $(this).text();
 
-        $('#packaging-color-select-' + orderItemId).val(data);
+        if (data == '') {
+            $('#packaging-color-select-' + orderItemId).val('packaging_color_1');
+        } else {
+            $('#packaging-color-select-' + orderItemId).val(data);
+        }
+        
     });
 
     /* Reflect fetched data about item color */
@@ -141,7 +146,12 @@ $(document).ready(function() {
         const orderItemId = getOrderItemId(this);
         const data = $(this).text();
 
-        $('#item-color-select-' + orderItemId).val(data);
+        if (data == '') {
+            $('#item-color-select-' + orderItemId).val('item_color_1');
+        } else {
+            $('#item-color-select-' + orderItemId).val(data);
+        }
+        
     });
 
     /* Reflect fetched data about location of company logo */


### PR DESCRIPTION
This is in response to the TODO mentioned in #81. Upon inspection, it was found that the bug belongs to the general category of the user ordering only a single product since the fields in `req.body` remain as strings (instead of arrays). As a result, the iteration resulted in iterating through its characters (rather than the element per se). 

This pull request resolves the aforementioned issue. Albeit unobserved in our testing to date, in order to prevent (future) problems related to `null` or `undefined` values, `default` cases were also added when dealing with input from radio buttons. 

**TODO @hyleene:** The modal seems to imply that clicking the Cancel button discards the data from the database as well (aside from redirecting the user away from the order page). 