### PR TITLE
Fix bug concerning leave page alert

### DIFF
--- a/public/js/order-product.js
+++ b/public/js/order-product.js
@@ -213,6 +213,11 @@ $(document).ready(function() {
         };
     });
 
+    /* Remove the alert about leaving the page if the user selects the OK option on the place order success modal */
+    $('#place-order-success-modal').on('click', function(e) {
+        window.onbeforeunload = null;
+    });
+
     /**
 	 * Format the preferred delivery date
 	 * 

--- a/views/order-product.hbs
+++ b/views/order-product.hbs
@@ -204,7 +204,7 @@
                 
                    
                 <div class = "container d-flex justify-content-center mt-4">
-                    <a class="btn cwhite bgc5 btn-anchor" href="/account/myOrders">Ok</a>
+                    <a class="btn cwhite bgc5 btn-anchor" href="/account/myOrders" id = "place-order-success-modal">Ok</a>
                 </div>
 
                     


### PR DESCRIPTION
Fix bug concerning the leave page alert upon clicking the place order success modal button (the leave page alert should no longer appear)